### PR TITLE
Example git diff wrapper script

### DIFF
--- a/eagle-diff-git
+++ b/eagle-diff-git
@@ -1,0 +1,16 @@
+#!/bin/sh
+# git diff wrapper to handle the fixed arguments that git diff needs
+# Usage: 
+# 1. add a git config block like (~/.gitconfig or project level if you prefer)
+# [diff "eagle"]
+#    command = path/to/this/script
+# 2. add a .gitattributes file in your project root with the following lines
+#   *.sch diff=eagle
+#   *.brd diff=eagle
+
+grep '.sch$' <<< $2 && DPI=100
+grep '.brd$' <<< $2 && DPI=600
+
+eagle-diff -f -d $DPI $2 $5
+APP=$(xdg-mime query default image/png | sed s/.desktop$//)
+$APP eagle_diff/*.png


### PR DESCRIPTION
Demonstrates opening up the system default app with multiple files.
(xdg-open can only open one file at a time)  This also lets you do git
diffs directly, rather than having to use "git difftool -t eagle" or
similar workarounds.

Not 100% sure if you want this in the main repo as is, but I've found it to be nice so far...